### PR TITLE
Add Python3 compability

### DIFF
--- a/nautilus-git/nautilus-git.py.in
+++ b/nautilus-git/nautilus-git.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 """
 Nautilus git pluging to show useful information under any
 git directory

--- a/nemo-git/nemo-git.py.in
+++ b/nemo-git/nemo-git.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python
 """
 Nemo git pluging to show useful information under any
 git directory

--- a/src/models/git.py
+++ b/src/models/git.py
@@ -17,9 +17,19 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nautilus-git. If not, see <http://www.gnu.org/licenses/>.
 """
-from ConfigParser import ConfigParser, NoSectionError
+
+# Try Python2 imports
+try:
+    from StringIO import StringIO
+    from ConfigParser import ConfigParser, NoSectionError
+
+# Python3 imports
+except ModuleNotFoundError:
+    from io import StringIO
+    from configparser import ConfigParser, NoSectionError
+
+
 from os import environ, path
-from StringIO import StringIO
 from sys import path as sys_path
 
 sys_path.insert(0, environ["SRC_DIR"])

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,8 +19,16 @@ along with nautilus-git. If not, see <http://www.gnu.org/licenses/>.
 """
 from os import path
 from subprocess import PIPE, Popen
-from urlparse import urlsplit
-from urllib2 import unquote
+
+# Try Python2 imports
+try:
+    from urllib2 import unquote
+    from urlparse import urlsplit
+
+# Python3 imports
+except ImportError or ModuleNotFoundError:
+    from urllib.parse import urlsplit, unquote
+
 
 def get_file_path(uri):
     """Return file path from an uri."""


### PR DESCRIPTION
# Description
I have updated the import statements such that they are compatible with Python3 while maintaining Python2 compatibility. I have not tested every little detail, but as far as I can tell, all features now work with Python2 and the Python2 bindings of ``python2-nautilus`` as well as Python3 and the correspondings ``python3-nautilus`` bindings.

What is left is to update the ``PKGBUILD`` of your Arch AUR package to be compatible with ``python2-nautilus`` as well as ``python-nautilus``.