### PR TITLE
Open URL for SSH cloned repositories

### DIFF
--- a/src/models/git.py
+++ b/src/models/git.py
@@ -102,7 +102,17 @@ class Git:
 
     def get_remote_url(self):
         """Return remote url."""
-        return execute("git config --get remote.origin.url", self.dir)
+        url = execute("git config --get remote.origin.url", self.dir)
+        if url[0:8] == "https://":
+            pass
+        elif url[0:4] == "git@":
+            # Remove git@ and .git in beginning/end and replace : with .
+            url = "https://" + url[4:-4]
+            url = url.replace(":", ".")
+        else:
+            raise RuntimeWarning("No valid url found for remote origin.")
+
+        return url
 
     def get_stat(self, filename):
         """Return file stat line added/removed."""

--- a/src/models/git.py
+++ b/src/models/git.py
@@ -113,7 +113,6 @@ class Git:
         else:
             raise RuntimeWarning("No valid url found for remote origin.")
 
-        print("FOUND URL: ", url)
         return url
 
     def get_stat(self, filename):

--- a/src/models/git.py
+++ b/src/models/git.py
@@ -106,12 +106,14 @@ class Git:
         if url[0:8] == "https://":
             pass
         elif url[0:4] == "git@":
-            # Remove git@ and .git in beginning/end and replace : with .
-            url = "https://" + url[4:-4]
-            url = url.replace(":", ".")
+            # Remove git@ and .git in beginning/end and replace : with /
+            url = url[4:-4]
+            url = url.replace(":", "/")
+            url = "https://" + url
         else:
             raise RuntimeWarning("No valid url found for remote origin.")
 
+        print("FOUND URL: ", url)
         return url
 
     def get_stat(self, filename):


### PR DESCRIPTION
# Description
This simple adaption makes it possible to open URLs for repositories that were cloned via SSH.

I simply modified the ``get_url`` method in the ``git.py`` file to deal with "URLs" starting with ``git@`` and convert them to URLs with ``https:\\``